### PR TITLE
Updated for Python 3 and POSIX based systems

### DIFF
--- a/webb/webb.py
+++ b/webb/webb.py
@@ -170,7 +170,7 @@ def download_page(url,*arg):
             else:
                 return page
         except Exception as e:
-            print str(e)
+            print (str(e))
 
 
 

--- a/webb/webb.py
+++ b/webb/webb.py
@@ -58,7 +58,6 @@ def traceroute(url,*arg):
     url = urlparse(url)
     url = url.netloc
     print(url)
-    print(os.name)
     if os.name == "posix":
         p = Popen(['traceroute', url], stdout=PIPE)
     else:

--- a/webb/webb.py
+++ b/webb/webb.py
@@ -12,6 +12,7 @@ import re
 import json as m_json
 import socket
 import urllib
+import os
 try:
     from urllib.parse import urlparse
 except ImportError:
@@ -57,7 +58,11 @@ def traceroute(url,*arg):
     url = urlparse(url)
     url = url.netloc
     print(url)
-    p = Popen(['tracert', url], stdout=PIPE)
+    print(os.name)
+    if os.name == "posix":
+        p = Popen(['traceroute', url], stdout=PIPE)
+    else:
+        p = Popen(['tracert', url], stdout=PIPE)
     while True:
         line = p.stdout.readline()
         line2 = str(line).replace('\\r','').replace('\\n','')


### PR DESCRIPTION
1. The underlying command 'tracert' is a Windows thing. Added functionality to check for Posix OS and run the associated 'traceroute' command instead.
2. Also updated for Python3 syntax